### PR TITLE
Bump acorn from 6.1.0 to 6.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {


### PR DESCRIPTION

[agorasdk.log](https://github.com/atlassian/gajira-comment/files/4907057/agorasdk.log)
Bumps [acorn](https://github.com/acornjs/acorn) from 6.1.0 to 6.4.1.
- [Release notes](https://github.com/acornjs/acorn/releases)
- [Commits](https://github.com/acornjs/acorn/compare/6.1.0...6.4.1)

Signed-off-by: dependabot[bot] <support@github.com>