### PR TITLE
Update Node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Comment
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: './dist/index.js'


### PR DESCRIPTION
This is to bypass the following warning



**What's in this PR?**

**Why**

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: atlassian/gajira-login@v3, atlassian/gajira-comment@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

**Affected issues**  
[_Jira Issues_](https://github.com/atlassian/gajira-comment/issues/45)

**How has this been tested?**  
_Include how to test if applicable_

**Whats Next?**
